### PR TITLE
ESN Driver Training

### DIFF
--- a/esnpy/io.py
+++ b/esnpy/io.py
@@ -15,7 +15,7 @@ def from_zarr(store, **kwargs):
     is_lazy = "overlap" in args
     esn = LazyESN(**args) if is_lazy else ESN(**args)
     esn.build()
-    Wout = xds["Wout"].data
+    Wout = xds["Wout"].data if is_lazy else xds["Wout"].values
 
     # Need to re-append singleton dimension
     if is_lazy:

--- a/esnpy/test/config-eager.yaml
+++ b/esnpy/test/config-eager.yaml
@@ -1,9 +1,7 @@
 xdata:
-    dimensions            : ['x', 'y', 'z', 'time']
-        #    delta_t               : 300
-        #    time_units            : s
+    dimensions            : ['x', 'time']
 #
-    zstore_path           : test-xdata.zarr
+    zstore_path           : eager-xdata.zarr
     field_name            : 'theta'
     subsampling:
         time:
@@ -15,23 +13,13 @@ xdata:
         bias            : 0.
         scale           : 2.
 
-LazyESN:
-    boundary            : periodic
+esn:
+    n_input             : 10
+    n_output            : 10
     n_reservoir         : 500
     connectedness       : 5
     leak_rate           : 0.5
     tikhonov_parameter  : 1.e-6
-    persist             : True
-#
-    data_chunks: [5, 5, 5, 1] 
-        #    x               : 5
-        #    y               : 5
-        #    z               : 5
-    overlap:
-        0               : 1
-        1               : 1
-        2               : 0
-        3               : 0
 #
     input_factor        : 1.0
     input_kwargs:

--- a/esnpy/test/config-lazy.yaml
+++ b/esnpy/test/config-lazy.yaml
@@ -1,0 +1,58 @@
+xdata:
+    dimensions            : ['x', 'y', 'z', 'time']
+        #    delta_t               : 300
+        #    time_units            : s
+#
+    zstore_path           : test-xdata.zarr
+    field_name            : 'theta'
+    subsampling:
+        time:
+            training    : [ null, 100, null]
+            validation  : [1_000, 1_500, null]
+            testing     : [1_500,  null, null]
+
+    normalization:
+        bias            : 0.
+        scale           : 2.
+
+lazyesn:
+    boundary            : periodic
+    n_reservoir         : 500
+    connectedness       : 5
+    leak_rate           : 0.5
+    tikhonov_parameter  : 1.e-6
+    persist             : True
+#
+    data_chunks: [5, 5, 5, 1] 
+        #    x               : 5
+        #    y               : 5
+        #    z               : 5
+    overlap:
+        0               : 1
+        1               : 1
+        2               : 0
+        3               : 0
+#
+    input_factor        : 1.0
+    input_kwargs:
+        distribution    : uniform
+        normalization   : svd
+        is_sparse       : False
+        random_seed     : 0
+#
+    adjacency_factor    : 1.0
+    adjacency_kwargs:
+        distribution    : uniform
+        normalization   : svd
+        is_sparse       : True
+        random_seed     : 1
+#
+    bias                : 0.5
+    bias_kwargs:
+        distribution    : uniform
+        normalization   : svd
+        random_seed     : 2
+
+training:
+    n_spinup            : 0
+    batch_size          : null

--- a/esnpy/test/esn.py
+++ b/esnpy/test/esn.py
@@ -267,6 +267,9 @@ class TestPrediction(TestESN):
 
         assert_allclose(esn.W.data, esn2.W.data)
 
+        # make sure Wout is a numpy array
+        assert isinstance(esn2.Wout, np.ndarray)
+
         v1 = esn.predict(u, n_steps=self.n_steps, n_spinup=1)
         v2= esn2.predict(u, n_steps=self.n_steps, n_spinup=1)
         assert_allclose(v1, v2)

--- a/esnpy/test/lazy.py
+++ b/esnpy/test/lazy.py
@@ -249,6 +249,9 @@ class TestPrediction(TestLazy):
 
         assert_allclose(esn.W.data, esn2.W.data)
 
+        # make sure Wout is a dask array
+        assert isinstance(esn2.Wout, darray.core.Array)
+
         v1 = esn.predict(u, n_steps=self.n_steps, n_spinup=1)
         v2= esn2.predict(u, n_steps=self.n_steps, n_spinup=1)
         assert_allclose(v1, v2)

--- a/esnpy/test/xdata.py
+++ b/esnpy/test/xdata.py
@@ -68,7 +68,8 @@ def test_data():
                 "time": np.linspace(0, 2000, 200),
                 },
             dims=tester.dimensions)
-    u.to_dataset(name=tester.field_name).to_zarr(tester.zstore_path, mode="w")
+    u.name = tester.field_name
+    u.to_dataset().to_zarr(tester.zstore_path, mode="w")
     yield u
     rmtree(tester.zstore_path)
 


### PR DESCRIPTION
- Adds ability to use eager ESN via driver/config
- When setting params in driver, make the section names lower case
- Make sure that when Wout is read from zarr it is dask for lazy and numpy for eager
- Remove output_dataset_filename... just save stuff and call it what it is